### PR TITLE
Modelで得たデータをViewController内でどのようにtableViewに反映させるのかわからず、詰まりました

### DIFF
--- a/MentaMVC.xcodeproj/project.pbxproj
+++ b/MentaMVC.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		7401509D25022F3000193BDB /* QiitaItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QiitaItems.swift; sourceTree = "<group>"; };
 		7401509F250233F500193BDB /* QiitaUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QiitaUser.swift; sourceTree = "<group>"; };
 		743661CA2502430600F62EA9 /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
-		743661EF2503637200F62EA9 /* ItemsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsModel.swift; sourceTree = "<group>"; };
+		743661EF2503637200F62EA9 /* ItemsModel.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ItemsModel.swift; sourceTree = "<group>"; tabWidth = 4; };
 		743661F12504A19700F62EA9 /* QiitaTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QiitaTags.swift; sourceTree = "<group>"; };
 		A533F7F824F0B613005B98AC /* ItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsViewController.swift; sourceTree = "<group>"; };
 		A533F7FA24F0B631005B98AC /* ItemsViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ItemsViewController.storyboard; sourceTree = "<group>"; };

--- a/MentaMVC/Model/ItemsModel.swift
+++ b/MentaMVC/Model/ItemsModel.swift
@@ -10,14 +10,14 @@ import Foundation
 import Alamofire
 
 protocol ItemsModelDelegate: AnyObject {
-    func onViewDidLoad(with someData: Data)
+    func getQiitaData(with somedata: Data)
 }
 
 final class ItemsModel {
     
     weak var delegate: ItemsModelDelegate?
     
-    func onViewDidLoad() {
+    func getQiitaData() {
         // ViewDidLoad でする処理
         let urlString = "https://qiita.com/api/v2/items?page=1&per_page=20"
         let url = URL(string: urlString)
@@ -29,6 +29,7 @@ final class ItemsModel {
                         guard let data = response.data else { return }
                         let qiitaItems = try JSONDecoder().decode([QiitaItems].self, from: data)
                         print(qiitaItems)
+                        print("===last call===")
                     } catch {
                         // デコードのエラー
                         print(error)

--- a/MentaMVC/Model/ItemsModel.swift
+++ b/MentaMVC/Model/ItemsModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 
 protocol ItemsModelDelegate: AnyObject {
-    func getQiitaData(with somedata: Data)
+    func getQiitaData(with: [QiitaItems])
 }
 
 final class ItemsModel {
@@ -28,8 +28,8 @@ final class ItemsModel {
                     do {
                         guard let data = response.data else { return }
                         let qiitaItems = try JSONDecoder().decode([QiitaItems].self, from: data)
-                        print(qiitaItems)
-                        print("===last call===")
+//                        print(qiitaItems)
+                        self.delegate?.getQiitaData(with: qiitaItems)
                     } catch {
                         // デコードのエラー
                         print(error)

--- a/MentaMVC/Model/ItemsModel.swift
+++ b/MentaMVC/Model/ItemsModel.swift
@@ -24,7 +24,6 @@ final class ItemsModel {
                         print(qiitaItems)
                     } catch {
                         // デコードのエラー
-                        print("---ここでエラー---")
                         print(error)
                     }
                 case .failure:

--- a/MentaMVC/Model/ItemsModel.swift
+++ b/MentaMVC/Model/ItemsModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 
 protocol ItemsModelDelegate: AnyObject {
-    func getQiitaData(with: [QiitaItems])
+    func getQiitaData(qiitaItems: [QiitaItems])
 }
 
 final class ItemsModel {
@@ -28,8 +28,8 @@ final class ItemsModel {
                     do {
                         guard let data = response.data else { return }
                         let qiitaItems = try JSONDecoder().decode([QiitaItems].self, from: data)
-//                        print(qiitaItems)
-                        self.delegate?.getQiitaData(with: qiitaItems)
+                        print(qiitaItems)
+                        self.delegate?.getQiitaData(qiitaItems: qiitaItems)
                     } catch {
                         // デコードのエラー
                         print(error)

--- a/MentaMVC/Model/ItemsModel.swift
+++ b/MentaMVC/Model/ItemsModel.swift
@@ -9,7 +9,14 @@
 import Foundation
 import Alamofire
 
+protocol ItemsModelDelegate: AnyObject {
+    func onViewDidLoad(with someData: Data)
+}
+
 final class ItemsModel {
+    
+    weak var delegate: ItemsModelDelegate?
+    
     func onViewDidLoad() {
         // ViewDidLoad でする処理
         let urlString = "https://qiita.com/api/v2/items?page=1&per_page=20"

--- a/MentaMVC/ViewController/Items/Cell/ItemsViewControllerCell.swift
+++ b/MentaMVC/ViewController/Items/Cell/ItemsViewControllerCell.swift
@@ -38,7 +38,7 @@ class ItemsViewControllerCell: UITableViewCell {
     
     // MARK: Configurations
     
-    func configureCell(profileImageURL: String?, title: String?, body: String?, tags: String?, likesCount: Int, commentsCount: Int) {
+  func configureCell(profileImageURL: String?, title: String?, body: String?, tags: String?, likesCount: Int, commentsCount: Int, url:String) {
         titleLabel.text = title
         bodyLabel.text = body
         tagsLabel.text = tags

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -18,6 +18,7 @@ final class ItemsViewController: UIViewController {
     // MARK: Properties
     
     private var dataSource: [ItemsViewControllerCellType] = []
+    private var urlArray: [String] = []
     
     // MARK: Lifecycle
     
@@ -80,7 +81,9 @@ extension ItemsViewController: UITableViewDataSource {
                 body: item.body,
                 tags: item.tags.reduce("") { $0 + "#\($1.name) " },
                 likesCount: item.likesCount,
-                commentsCount: item.commentsCount)
+                commentsCount: item.commentsCount,
+                url: item.url)
+                urlArray.append(item.url)
             return cell
         case .indicator:
             let cell = tableView.dequeueReusableCell(withIdentifier: ItemsViewControllerIndicatorCell.reuseIdentifier, for: indexPath) as! ItemsViewControllerIndicatorCell
@@ -97,7 +100,7 @@ extension ItemsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        guard let url = URL(string: "https://qiita.com/hayabusabusa/items/54838ab2d7862b5a04dd") else { return }
+        guard let url = URL(string: urlArray[indexPath.row]) else { return }
         let vc = SafariViewController(url: url)
         present(vc, animated: true, completion: nil)
     }

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -34,6 +34,18 @@ final class ItemsViewController: UIViewController {
         configureNavigation()
         configureTableView()
         itemsModel.onViewDidLoad()
+        itemsModel.delegate = self
+    }
+}
+
+extension ItemsViewController: ItemsModelDelegate {
+    func onViewDidLoad(with someData: Data) {
+        //modelで得たデータの処理
+        //すでにデコードされた記事データを取得してある → tableViewに映せばいいのでは？ → cellForlowAtに取得したデータを渡す → すでにcellForlowAtに記述されているデータどうするのか？
+      let a = Data()
+      print("=====") //そもそも呼ばれていない・・・
+      print(a)
+      print("=====")
     }
 }
 

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -31,8 +31,9 @@ final class ItemsViewController: UIViewController {
 }
 
 extension ItemsViewController: ItemsModelDelegate {
-    func getQiitaData(with somedata: Data) {
-        print("=====ここチェック") //呼ばれていない なぜ？
+    func getQiitaData(with: [QiitaItems]) {
+        //modelから[QiitaItems]型のデータを受け取った
+        print(with)
     }
 }
 

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -18,7 +18,6 @@ final class ItemsViewController: UIViewController {
     // MARK: Properties
     
     private var dataSource: [ItemsViewControllerCellType] = []
-    private var urlArray: [String] = []
     
     // MARK: Lifecycle
     
@@ -83,7 +82,6 @@ extension ItemsViewController: UITableViewDataSource {
                 likesCount: item.likesCount,
                 commentsCount: item.commentsCount,
                 url: item.url)
-                urlArray.append(item.url)
             return cell
         case .indicator:
             let cell = tableView.dequeueReusableCell(withIdentifier: ItemsViewControllerIndicatorCell.reuseIdentifier, for: indexPath) as! ItemsViewControllerIndicatorCell
@@ -100,8 +98,16 @@ extension ItemsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        guard let url = URL(string: urlArray[indexPath.row]) else { return }
-        let vc = SafariViewController(url: url)
-        present(vc, animated: true, completion: nil)
+        let cellType = dataSource[indexPath.row]
+      
+        switch cellType {
+        case .item(let item):
+            guard let url = URL(string: item.url) else { return }
+            let vc = SafariViewController(url: url)
+            present(vc, animated: true, completion: nil)
+        default:
+            break
+        }
+        
     }
 }

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -17,15 +17,7 @@ final class ItemsViewController: UIViewController {
     
     // MARK: Properties
     
-    private var dataSource: [ItemsViewControllerCellType] = [
-        .item,
-        .item,
-        .item,
-        .item,
-        .item,
-        .item,
-        .indicator
-    ]
+    private var dataSource: [ItemsViewControllerCellType] = []
     
     // MARK: Lifecycle
     
@@ -33,19 +25,14 @@ final class ItemsViewController: UIViewController {
         super.viewDidLoad()
         configureNavigation()
         configureTableView()
-        itemsModel.onViewDidLoad()
         itemsModel.delegate = self
+        itemsModel.getQiitaData()
     }
 }
 
 extension ItemsViewController: ItemsModelDelegate {
-    func onViewDidLoad(with someData: Data) {
-        //modelで得たデータの処理
-        //すでにデコードされた記事データを取得してある → tableViewに映せばいいのでは？ → cellForlowAtに取得したデータを渡す → すでにcellForlowAtに記述されているデータどうするのか？
-      let a = Data()
-      print("=====") //そもそも呼ばれていない・・・
-      print(a)
-      print("=====")
+    func getQiitaData(with somedata: Data) {
+        print("=====ここチェック") //呼ばれていない なぜ？
     }
 }
 
@@ -81,17 +68,17 @@ extension ItemsViewController: UITableViewDataSource {
         let cellType = dataSource[indexPath.row]
         
         switch cellType {
-        case .item:
+        case .item(let item):
             let cell = tableView.dequeueReusableCell(withIdentifier: ItemsViewControllerCell.reuseIdentifier, for: indexPath) as! ItemsViewControllerCell
             
             // TODO: Model オブジェクト作成後に修正する.
             cell.configureCell(
-                profileImageURL: "https://qiita-user-profile-images.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F202306%2Fprofile-images%2F1566547186?ixlib=rb-1.2.2&auto=compress%2Cformat&lossless=0&w=48&s=6949bc566d9b66c71fcddd7af98dda73",
-                title: "RxSwiftとRxCocoaを使ってストップウォッチを作る",
-                body: "去年からRxSwiftをしっかり使い始めて、ようやく慣れてきたので今回はRxSwiftとRxCocoaを使ってストップウォッチのようなタイマーを作ってみます。",
-                tags: ["iOS", "Swift", "RxSwift", "RxCocoa", "iOS", "Swift", "RxSwift", "RxCocoa"].reduce("") { $0 + "#\($1) " },
-                likesCount: 2,
-                commentsCount: 0)
+                profileImageURL: item.user.profileImageURL,
+                title: item.title,
+                body: item.body,
+                tags: item.tags.reduce("") { $0 + "#\($1.name) " },
+                likesCount: item.likesCount,
+                commentsCount: item.commentsCount)
             return cell
         case .indicator:
             let cell = tableView.dequeueReusableCell(withIdentifier: ItemsViewControllerIndicatorCell.reuseIdentifier, for: indexPath) as! ItemsViewControllerIndicatorCell

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -31,9 +31,9 @@ final class ItemsViewController: UIViewController {
 }
 
 extension ItemsViewController: ItemsModelDelegate {
-    func getQiitaData(with: [QiitaItems]) {
+    func getQiitaData(qiitaItems: [QiitaItems]) {
         //modelから[QiitaItems]型のデータを受け取った
-        print(with)
+        print(qiitaItems)
     }
 }
 

--- a/MentaMVC/ViewController/Items/ItemsViewController.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewController.swift
@@ -32,8 +32,9 @@ final class ItemsViewController: UIViewController {
 
 extension ItemsViewController: ItemsModelDelegate {
     func getQiitaData(qiitaItems: [QiitaItems]) {
-        //modelから[QiitaItems]型のデータを受け取った
-        print(qiitaItems)
+        let dataSource = qiitaItems.map { ItemsViewControllerCellType.item(with: $0) }
+        self.dataSource = dataSource
+        tableView.reloadData()
     }
 }
 

--- a/MentaMVC/ViewController/Items/ItemsViewControllerCellType.swift
+++ b/MentaMVC/ViewController/Items/ItemsViewControllerCellType.swift
@@ -10,6 +10,6 @@ import Foundation
 
 enum ItemsViewControllerCellType {
     // TODO: Model オブジェクト作成後に修正する.
-    case item
+    case item(with: QiitaItems)
     case indicator
 }


### PR DESCRIPTION
@hayabusabusa 
## 詰まったところ
MentaMVC/ViewController/Items/ItemsViewController.swift の43-48行目
Modelで得たデータをViewController内でどのようにtableViewに反映させるのかわからず、詰まりました。
すでにcellForLowAt内に記述があるものは削除してよいのでしょうか？
またすでにコードに簡易なデバッグがあるのですが、そもそも`func onViewDidLoad(with someData: Data)`が呼ばれていないことに気付きました。delegateの内容は定義して渡していると思うのですが、なぜ呼ばれていないのでしょうか？
原因を自力で調べることができなかったので解説お願い致します。

## 質問
1.MentaMVC/Model/ItemsModel.swift 12行目
`protocol ItemsModelDelegate: AnyObject`と型がわからなかったので、とりあえず実装のヒントにしたがってAnyObjectにしました。どんな型でも対応できる(?)AnyObjectって便利だなと思ったのですが、使う時の注意点とかありますか？

2.MentaMVC/Model/ItemsModel.swift 13行目
`func onViewDidLoad(with someData: Data)`の引数の書き方がわからないです。左記は合っているのでしょうか？

3.MentaMVC/Model/ItemsModel.swift 18行目
`weak var delegate: ItemsModelDelegate?`の弱参照について調べました。わかるようで、わからなかったです。
おそらく参照カウンタが0になった時(`onViewDidLoad`で得た値がnilだった時)に、nilを返すようにしたいのかなと思ったのですが、そもそも`onViewDidLoad`で得る値にnil入らないなと思い、完全にわからなくなったので解説お願い致します。

また`delegate`が`var`で宣言されていて、`delegate`そのものの値が変化しないんじゃないかと思い、`let`に変更したところ以下のエラーメッセージがでました。
**`'weak' must be a mutable variable, because it may change at runtime`**
"アプリを起動したらすぐに値が変わるのでエラーです"という意味だと思うのですが、`delegate`が変わるというのがピンとこないです。アプリ起動時に`ItemsModelDelegate`プロトコルが呼ばれたから、呼ばれる前と変化してるということでしょうか？

[弱参照の参考記事1](https://qiita.com/kwst/items/6c780f3e87110a6a68b6)
[弱参照の参考記事2](https://komukomu.hatenablog.com/entry/2016/09/20/161906)

4.MentaMVC/ViewController/Items/ItemsViewController.swift 41行目
細かいところで大変恐縮なのですが`extension XXXDelegate`という記述が多々あり、単純に`extension`を使ったことがなかったので不思議に思ったのですが、なぜUITableViewDelegateのところも今回のDelegateも11行目の`ItemsViewController`の横にDelegateを記述するのでなく、`extension XXXDelegate`という記述にしているのでしょうか？